### PR TITLE
Adds Apos pages to the Gatsby GraphQL API

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": [ "apostrophe" ]
+  "extends": [ "apostrophe" ],
+  "rules": {
+    "no-console": ["error", { "allow": ["warn", "error"] }]
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 1.0.0-beta
+
+The initial release of a Gatsby source plugin that connects to ApostropheCMS sites, providing:
+
+- Documentation for connecting a Gatsby site to an ApostropheCMS project
+- GraphQL queries to pull piece data from specifically identified piece types
+- GraphQL queries to use Apostrophe page data, including rendered HTML for the page

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Defaults to `true`. Set this to `false` to avoid an additional request for each 
 
 Apostrophe content node types in Gatsby's GraphQL API are all prefixed with `Apos`. So if you include your `article` piece type, it will appear in the GraphQL API as `AposArticle` nodes and the query collections will be `aposArticle` and `allAposArticle`.
 
-Apostrophe core piece types and pages are prefixed `AposCore`. For example, including the core `@apostrophecms/file` piece type will create `AposCoreFile` nodes.
+Apostrophe core piece types and pages are prefixed `AposCore`. For example, including the core `@apostrophecms/file` piece type will create `AposCoreFile` nodes. Other scoped module names will be converted to pascal-case, removing punctuation, and prefixed with `Apos`. For example, `@skynet/bad-robots` and `@skynet/badRobots` will be converted to `AposSkynetBadRobots`.
 
 ### Rendered content
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The base URL for API requests. Usually this will be the root domain of the Apost
 
 ### pieceTypes
 
-An array of Apostrophe piece type names. These will the same as the key name entered in the `app.js` `modules` object in the Apostrophe app. You may include core piece types that are not included by default, e.g, `apostrophe/file`, `apostrophe/image-tag`.
+An array of Apostrophe piece type names. These will the same as the key name entered in the `app.js` `modules` object in the Apostrophe app. You may include core piece types that are not included by default, e.g, `@apostrophecms/file`, `@apostrophecms/image-tag`.
 
 ### renderPages
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Source plugin for accessing [ApostropheCMS 3.x content APIs](https://a3.docs.apo
 1. Review [Gatsby documentation on using source plugins](https://www.gatsbyjs.com/docs/tutorial/part-five/). 🤓
 1. [Add an API key to the Apostrophe app](https://a3.docs.apos.dev/reference/api/authentication.html#api-keys) to include as the `apiKey` option.
 2. Enter the Apos app root domain as the `baseUrl` option. For local development this will likely be `http://localhost:3000`.
-3. Add an array of the piece types (custom content types) you want available to Gatsby in the `pieceTypes` array. These will the same as the key name entered in the `app.js` `modules` object in the Apostrophe app. You may include core piece types that are not included by default, e.g, `apostrophe/file`, `apostrophe/image-tag`.
+3. Add an array of the piece types (custom content types) you want available to Gatsby in the `pieceTypes` array.
 
 ```javascript
 // In your gatsby-config.js
@@ -31,6 +31,38 @@ module.exports = {
   ]
 }
 ```
+
+## Options
+
+### apiKey (required)
+
+An ApostropheCMS API key with permissions to make GET requests. [Read more about setting up API keys](https://a3.docs.apos.dev/reference/api/authentication.html#api-keys) in the Apostrophe documentation.
+
+### baseUrl (required)
+
+The base URL for API requests. Usually this will be the root domain of the Apostrophe website or application with no trailing slash. In local development it will be `http://localhost:3000` by default.
+
+### pieceTypes
+
+An array of Apostrophe piece type names. These will the same as the key name entered in the `app.js` `modules` object in the Apostrophe app. You may include core piece types that are not included by default, e.g, `apostrophe/file`, `apostrophe/image-tag`.
+
+### renderPages
+
+Defaults to `true`. Set this to `false` to avoid an additional request for each Apostrophe page in order to add the page's rendered HTML to the `AposCorePage` nodes.
+
+## Notes
+
+### Naming
+
+Apostrophe content node types in Gatsby's GraphQL API are all prefixed with `Apos`. So if you include your `article` piece type, it will appear in the GraphQL API as `AposArticle` nodes and the query collections will be `aposArticle` and `allAposArticle`.
+
+Apostrophe core piece types and pages are prefixed `AposCore`. For example, including the core `@apostrophecms/file` piece type will create `AposCoreFile` nodes.
+
+### Rendered content
+
+Apostrophe pieces are well suited to being delivered as structured, JSON-like data. Apostrophe pages, on the other hand, usually consist primarily of the flexible content "areas," populated with any number of different widget types. It powers Apostrophe's great in-context editing experience, but the raw data is not easy to use in a page template on your own.
+
+Unless you add `renderPages: false` to this source plugin's options, pages will appear with a `_rendered` property in Gatsby GraphQL queries. This property's value is a string of HTML, rendered using the relevant page template in the Apostrophe app. That HTML can be used in your Gatsby site to [programmatically create pages](https://www.gatsbyjs.com/docs/tutorial/part-seven/) using the right layout component and slug structure for your site.
 
 ## Planned features
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -51,6 +51,6 @@ exports.sourceNodes = async ({
     baseUrl: options.baseUrl,
     apiRouteBase,
     apiKey: options.apiKey,
-    renderPage: options.renderPage
+    renderPages: options.renderPages
   }, gatsbyUtils);
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -16,6 +16,7 @@ exports.sourceNodes = async ({
   getNodesByType
 }, options) => {
   options = options || {};
+  const { createNode } = actions;
 
   if (!options.baseUrl) {
     throw Error('You are missing the `baseUrl` option for gatsby-source-apostrophe');
@@ -24,10 +25,12 @@ exports.sourceNodes = async ({
     throw Error('You are missing the `apiKey` option for gatsby-source-apostrophe');
   }
 
+  const routePathBase = options.routeBase || 'api/v1';
+  const apiRouteBase = `${options.baseUrl}/${routePathBase}`;
+
   if (Array.isArray(options.pieceTypes)) {
-    const routeBase = options.routeBase || 'api/v1';
     for (const type of options.pieceTypes) {
-      const route = `${options.baseUrl}/${routeBase}/${type}`;
+      const route = `${apiRouteBase}/${type}`;
       const response = await fetch(`${route}?apikey=${options.apiKey}`);
       const data = await response.json();
       const totalPages = data.pages;
@@ -53,26 +56,75 @@ exports.sourceNodes = async ({
     }
   }
 
-  async function generatePieceNodes (pieces, nodeType) {
-    const { createNode } = actions;
-    // loop through data and create Gatsby nodes
-    pieces.forEach(piece => {
-      piece.aposId = piece._id;
-      piece._id = undefined;
-      createNode({
-        ...piece,
-        id: createNodeId(`${nodeType}-${piece.aposId}`),
-        parent: null,
-        children: [],
-        internal: {
-          type: nodeType,
-          content: JSON.stringify(piece),
-          contentDigest: createContentDigest(piece)
-        }
-      });
+  const pageIds = await getPageIds(apiRouteBase, {
+    apiKey: options.apiKey
+  });
+
+  await generatePageNodes(pageIds, {
+    apiRouteBase,
+    apiKey: options.apiKey
+  });
+
+  function generateNode(data, nodeType) {
+    data.aposId = data._id;
+    data._id = undefined;
+    createNode({
+      ...data,
+      id: createNodeId(`${nodeType}-${data.aposId}`),
+      parent: null,
+      children: [],
+      internal: {
+        type: nodeType,
+        content: JSON.stringify(data),
+        contentDigest: createContentDigest(data)
+      }
     });
   }
+
+  async function generatePieceNodes (pieces, nodeType) {
+    // loop through data and create Gatsby nodes
+    pieces.forEach(piece => {
+      generateNode(piece, nodeType);
+    });
+  }
+
+  async function generatePageNodes(ids, { apiRouteBase, apiKey }) {
+    for (const id of ids) {
+      let page;
+
+      try {
+        const response = await fetch(`${apiRouteBase}/@apostrophecms/page/${id}?apikey=${apiKey}`);
+        page = await response.json();
+      } catch (error) {
+        console.error(`Error requesting Apostrophe page with ID ${id}`, error);
+        return;
+      }
+
+      if (!page || page.message === 'notfound') {
+        // This is most likely the trash "page"
+        console.warn(`No page found for Apostrophe document ID ${id}.`);
+        return;
+      }
+
+      cleanupPage(page);
+
+      generateNode(page, 'AposCorePage');
+    }
+  }
 };
+
+// TODO Add option to override `superfluous`.
+function cleanupPage(page) {
+  // Remove document properties unneeded by Gatsby.
+  const superflous = [
+    'orphan', 'parkedId', 'parked', 'updatedBy',
+    'highSearchText', 'highsearchWords', 'lowSearchText', 'searchSummary',
+    'historicUrls', '_edit', '_ancestors', '_children'
+  ];
+  superflous.forEach(prop => {
+    page[prop] = undefined;
+  });
+}
 
 function isAposCoreType(name) {
   return name.length > 15 && name.slice(0, 15) === '@apostrophecms/';
@@ -89,4 +141,16 @@ async function getPiecePage(route, opts) {
   const response = await fetch(`${route}?apikey=${opts.apiKey}&page=${opts.page}`);
   const data = await response.json();
   return data.results;
+}
+
+async function getPageIds(routeBase, opts) {
+  try {
+    const response = await fetch(`${routeBase}/@apostrophecms/page?apikey=${opts.apiKey}&all=1&flat=1`);
+    const data = await response.json();
+    const pages = data.results.filter(doc => doc.type !== '@apostrophecms/trash');
+    return pages.map(page => page._id);
+  } catch (error) {
+    console.error('Error requesting Apostrophe page IDs:', error);
+    return [];
+  }
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,16 +4,18 @@
  *
  * See: https://www.gatsbyjs.com/docs/node-apis/
  */
-const fetch = require('node-fetch').default;
-const camelcase = require('camelcase').default;
+const {
+  processPieceTypes
+} = require('./lib/pieces');
+const {
+  getPageIds,
+  generatePageNodes
+} = require('./lib/pages');
 
-// TEMP: disabling console log warning.
-/* eslint-disable no-console */
 exports.sourceNodes = async ({
   actions,
   createContentDigest,
-  createNodeId,
-  getNodesByType
+  createNodeId
 }, options) => {
   options = options || {};
   const { createNode } = actions;
@@ -25,35 +27,20 @@ exports.sourceNodes = async ({
     throw Error('You are missing the `apiKey` option for gatsby-source-apostrophe');
   }
 
+  const gatsbyUtils = {
+    createNode,
+    createNodeId,
+    createContentDigest
+  };
+
   const routePathBase = options.routeBase || 'api/v1';
   const apiRouteBase = `${options.baseUrl}/${routePathBase}`;
 
   if (Array.isArray(options.pieceTypes)) {
-    for (const type of options.pieceTypes) {
-      const route = `${apiRouteBase}/${type}`;
-      const response = await fetch(`${route}?apikey=${options.apiKey}`);
-      const data = await response.json();
-      const totalPages = data.pages;
-
-      const nodeTypeName = isAposCoreType(type)
-        ? convertCoreType(type)
-        : `Apos${camelcase(type, { pascalCase: true })}`;
-
-      await generatePieceNodes(data.results, nodeTypeName);
-
-      if (totalPages <= 1) {
-        continue;
-      };
-
-      for (let i = 2; i <= totalPages; i++) {
-        const pageResults = await getPiecePage(route, {
-          apiKey: options.apiKey,
-          page: i
-        });
-        await generatePieceNodes(pageResults, nodeTypeName);
-      }
-
-    }
+    await processPieceTypes(options.pieceTypes, {
+      apiRouteBase,
+      apiKey: options.apiKey
+    }, gatsbyUtils);
   }
 
   const pageIds = await getPageIds(apiRouteBase, {
@@ -63,94 +50,5 @@ exports.sourceNodes = async ({
   await generatePageNodes(pageIds, {
     apiRouteBase,
     apiKey: options.apiKey
-  });
-
-  function generateNode(data, nodeType) {
-    data.aposId = data._id;
-    data._id = undefined;
-    createNode({
-      ...data,
-      id: createNodeId(`${nodeType}-${data.aposId}`),
-      parent: null,
-      children: [],
-      internal: {
-        type: nodeType,
-        content: JSON.stringify(data),
-        contentDigest: createContentDigest(data)
-      }
-    });
-  }
-
-  async function generatePieceNodes (pieces, nodeType) {
-    // loop through data and create Gatsby nodes
-    pieces.forEach(piece => {
-      generateNode(piece, nodeType);
-    });
-  }
-
-  async function generatePageNodes(ids, { apiRouteBase, apiKey }) {
-    for (const id of ids) {
-      let page;
-
-      try {
-        const response = await fetch(`${apiRouteBase}/@apostrophecms/page/${id}?apikey=${apiKey}`);
-        page = await response.json();
-      } catch (error) {
-        console.error(`Error requesting Apostrophe page with ID ${id}`, error);
-        return;
-      }
-
-      if (!page || page.message === 'notfound') {
-        // This is most likely the trash "page"
-        console.warn(`No page found for Apostrophe document ID ${id}.`);
-        return;
-      }
-
-      cleanupPage(page);
-
-      generateNode(page, 'AposCorePage');
-    }
-  }
+  }, gatsbyUtils);
 };
-
-// TODO Add option to override `superfluous`.
-function cleanupPage(page) {
-  // Remove document properties unneeded by Gatsby.
-  const superflous = [
-    'orphan', 'parkedId', 'parked', 'updatedBy',
-    'highSearchText', 'highsearchWords', 'lowSearchText', 'searchSummary',
-    'historicUrls', '_edit', '_ancestors', '_children'
-  ];
-  superflous.forEach(prop => {
-    page[prop] = undefined;
-  });
-}
-
-function isAposCoreType(name) {
-  return name.length > 15 && name.slice(0, 15) === '@apostrophecms/';
-}
-
-function convertCoreType (aposType) {
-  let typeName = aposType.split('/')[1];
-
-  typeName = camelcase(typeName, { pascalCase: true });
-  return `AposCore${typeName}`;
-}
-
-async function getPiecePage(route, opts) {
-  const response = await fetch(`${route}?apikey=${opts.apiKey}&page=${opts.page}`);
-  const data = await response.json();
-  return data.results;
-}
-
-async function getPageIds(routeBase, opts) {
-  try {
-    const response = await fetch(`${routeBase}/@apostrophecms/page?apikey=${opts.apiKey}&all=1&flat=1`);
-    const data = await response.json();
-    const pages = data.results.filter(doc => doc.type !== '@apostrophecms/trash');
-    return pages.map(page => page._id);
-  } catch (error) {
-    console.error('Error requesting Apostrophe page IDs:', error);
-    return [];
-  }
-}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -48,7 +48,9 @@ exports.sourceNodes = async ({
   });
 
   await generatePageNodes(pageIds, {
+    baseUrl: options.baseUrl,
     apiRouteBase,
-    apiKey: options.apiKey
+    apiKey: options.apiKey,
+    renderPage: options.renderPage
   }, gatsbyUtils);
 };

--- a/lib/nodes.js
+++ b/lib/nodes.js
@@ -1,0 +1,17 @@
+module.exports = {
+  generateNode: function (data, nodeType, utils) {
+    data.aposId = data._id;
+    data._id = undefined;
+    utils.createNode({
+      ...data,
+      id: utils.createNodeId(`${nodeType}-${data.aposId}`),
+      parent: null,
+      children: [],
+      internal: {
+        type: nodeType,
+        content: JSON.stringify(data),
+        contentDigest: utils.createContentDigest(data)
+      }
+    });
+  }
+};

--- a/lib/pages.js
+++ b/lib/pages.js
@@ -13,7 +13,9 @@ module.exports = {
       return [];
     }
   },
-  generatePageNodes: async function (ids, { apiRouteBase, apiKey }, utils) {
+  generatePageNodes: async function (ids, {
+    baseUrl, apiRouteBase, apiKey, renderPage
+  }, utils) {
     for (const id of ids) {
       let page;
 
@@ -29,6 +31,10 @@ module.exports = {
         // This is most likely the trash "page"
         console.warn(`No page found for Apostrophe document ID ${id}.`);
         return;
+      }
+
+      if (renderPage !== false && page._url) {
+        await addRenderedContent(page, baseUrl);
       }
 
       cleanupPage(page);
@@ -49,4 +55,9 @@ function cleanupPage(page) {
   superflous.forEach(prop => {
     page[prop] = undefined;
   });
+}
+
+async function addRenderedContent(page, apiBaseUrl) {
+  const response = await fetch(`${apiBaseUrl}${page._url}?apos-refresh=1`);
+  page._rendered = await response.text();
 }

--- a/lib/pages.js
+++ b/lib/pages.js
@@ -1,0 +1,52 @@
+const { generateNode } = require('./nodes');
+const fetch = require('node-fetch').default;
+
+module.exports = {
+  getPageIds: async function (routeBase, opts) {
+    try {
+      const response = await fetch(`${routeBase}/@apostrophecms/page?apikey=${opts.apiKey}&all=1&flat=1`);
+      const data = await response.json();
+      const pages = data.results.filter(doc => doc.type !== '@apostrophecms/trash');
+      return pages.map(page => page._id);
+    } catch (error) {
+      console.error('Error requesting Apostrophe page IDs:', error);
+      return [];
+    }
+  },
+  generatePageNodes: async function (ids, { apiRouteBase, apiKey }, utils) {
+    for (const id of ids) {
+      let page;
+
+      try {
+        const response = await fetch(`${apiRouteBase}/@apostrophecms/page/${id}?apikey=${apiKey}`);
+        page = await response.json();
+      } catch (error) {
+        console.error(`Error requesting Apostrophe page with ID ${id}`, error);
+        return;
+      }
+
+      if (!page || page.message === 'notfound') {
+        // This is most likely the trash "page"
+        console.warn(`No page found for Apostrophe document ID ${id}.`);
+        return;
+      }
+
+      cleanupPage(page);
+
+      generateNode(page, 'AposCorePage', utils);
+    }
+  }
+};
+
+// TODO Add option to override `superfluous`.
+function cleanupPage(page) {
+  // Remove document properties unneeded by Gatsby.
+  const superflous = [
+    'orphan', 'parkedId', 'parked', 'updatedBy',
+    'highSearchText', 'highsearchWords', 'lowSearchText', 'searchSummary',
+    'historicUrls', '_edit', '_ancestors', '_children'
+  ];
+  superflous.forEach(prop => {
+    page[prop] = undefined;
+  });
+}

--- a/lib/pages.js
+++ b/lib/pages.js
@@ -14,7 +14,7 @@ module.exports = {
     }
   },
   generatePageNodes: async function (ids, {
-    baseUrl, apiRouteBase, apiKey, renderPage
+    baseUrl, apiRouteBase, apiKey, renderPages
   }, utils) {
     for (const id of ids) {
       let page;
@@ -33,7 +33,7 @@ module.exports = {
         return;
       }
 
-      if (renderPage !== false && page._url) {
+      if (renderPages !== false && page._url) {
         await addRenderedContent(page, baseUrl);
       }
 

--- a/lib/pieces.js
+++ b/lib/pieces.js
@@ -21,8 +21,8 @@ module.exports = {
       }
       const totalPages = data.pages;
 
-      const nodeTypeName = isAposCoreType(type)
-        ? convertCoreType(type)
+      const nodeTypeName = isNamespaced(type)
+        ? convertNamespacing(type)
         : `Apos${camelcase(type, { pascalCase: true })}`;
 
       await generatePieceNodes(data.results, nodeTypeName, utils);
@@ -50,15 +50,19 @@ async function generatePieceNodes (pieces, nodeType, utils) {
   });
 }
 
-function isAposCoreType(name) {
-  return name.length > 15 && name.slice(0, 15) === '@apostrophecms/';
+function isNamespaced(name) {
+  return name.match(/^@[A-Za-z0-9]*\/[A-Za-z0-9]*$/);
 }
 
-function convertCoreType (aposType) {
-  let typeName = aposType.split('/')[1];
-
-  typeName = camelcase(typeName, { pascalCase: true });
-  return `AposCore${typeName}`;
+function convertNamespacing (name) {
+  if (name.match(/^@apostrophecms\/[A-Za-z0-9]*$/)) {
+    let typeName = name.split('/')[1];
+    typeName = camelcase(typeName, { pascalCase: true });
+    return `AposCore${typeName}`;
+  } else {
+    const cleanedName = name.slice(1).split('/').join('-');
+    return `Apos${camelcase(cleanedName, { pascalCase: true })}`;
+  }
 }
 
 async function getPiecePage(route, opts) {

--- a/lib/pieces.js
+++ b/lib/pieces.js
@@ -1,0 +1,68 @@
+const { generateNode } = require('./nodes');
+const camelcase = require('camelcase').default;
+const fetch = require('node-fetch').default;
+
+module.exports = {
+  processPieceTypes: async function (pieceTypes, { apiRouteBase, apiKey }, utils) {
+    for (const type of pieceTypes) {
+      const route = `${apiRouteBase}/${type}?apikey=${apiKey}`;
+      let data;
+
+      try {
+        const response = await fetch(route);
+        data = await response.json();
+      } catch (error) {
+        console.error('Error requesting Apostrophe pieces:', error);
+        continue;
+      }
+
+      if (!data.results) {
+        continue;
+      }
+      const totalPages = data.pages;
+
+      const nodeTypeName = isAposCoreType(type)
+        ? convertCoreType(type)
+        : `Apos${camelcase(type, { pascalCase: true })}`;
+
+      await generatePieceNodes(data.results, nodeTypeName, utils);
+
+      if (totalPages <= 1) {
+        continue;
+      };
+
+      for (let i = 2; i <= totalPages; i++) {
+        const pageResults = await getPiecePage(route, {
+          apiKey: apiKey,
+          page: i
+        });
+        await generatePieceNodes(pageResults, nodeTypeName, utils);
+      }
+
+    }
+  }
+};
+
+async function generatePieceNodes (pieces, nodeType, utils) {
+  // loop through data and create Gatsby nodes
+  pieces.forEach(piece => {
+    generateNode(piece, nodeType, utils);
+  });
+}
+
+function isAposCoreType(name) {
+  return name.length > 15 && name.slice(0, 15) === '@apostrophecms/';
+}
+
+function convertCoreType (aposType) {
+  let typeName = aposType.split('/')[1];
+
+  typeName = camelcase(typeName, { pascalCase: true });
+  return `AposCore${typeName}`;
+}
+
+async function getPiecePage(route, opts) {
+  const response = await fetch(`${route}?apikey=${opts.apiKey}&page=${opts.page}`);
+  const data = await response.json();
+  return data.results;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-apostrophe",
-  "version": "1.0.0-alpha",
+  "version": "1.0.0-beta",
   "description": "An ApostropheCMS source plugin for Gatsby",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Pages are added, including (by default) a `_rendered` property with the rendered refreshable HTML.